### PR TITLE
Add simple path handling in handler

### DIFF
--- a/storeganise/handler.js
+++ b/storeganise/handler.js
@@ -1,7 +1,42 @@
+const { FinverseSdk } = require('./sdk/finverse');
+const { StoreganiseSdk } = require('./sdk/storeganise');
+
+// the business code is a non-sensitive field. e.g. "dev-finverse"
+// it is okay to store this field as a run-time variable
+const storeganiseBusinessCode = process.env.storeganise_business_code;
+
+// the storeganise API key is a sensitive field that should be stored in the appropriate location for secrets
+// currently storing it as a runtime variable as part of v1. Should move to secret manager as part of official production-ization
+const storeganiseApiKey = process.env.storeganise_api_key;
+
+// Finverse client id and secrets are sensitive fields and should be stored in the appropriate location for secrets
+// currently string as runtime variables as part of v1. Should move to secret manager as part of official production-ization
+const finverseClientId = process.env.finverse_client_id;
+const finverseClientSecret = process.env.finverse_client_secret;
+
 // This function will handle the incoming HTTP request (i.e. the webhook)
 async function finverseWebhookHandler(req, res) {
-  // TODO: Add handling logic, for now just return 200
-  return res.send('OK');
+  const _finverseSdk = new FinverseSdk(finverseClientId, finverseClientSecret);
+  const _storeganiseSdk = new StoreganiseSdk(
+    storeganiseBusinessCode,
+    storeganiseApiKey
+  );
+
+  // TODO: Should verify signature of webhook and ensure it is from Finverse
+
+  // will handle payments webhooks
+  if (req.path === '/payments') {
+    // TODO: Handle payment webhooks
+    return res.send('OK');
+  }
+
+  // will handle payment link webhooks
+  if (req.path === '/payment_links') {
+    // TODO: Handle payment link webhooks
+    return res.send('OK');
+  }
+
+  return res.status(404).send(`Path not found: ${req.path}`);
 }
 
 module.exports = {

--- a/storeganise/handler.js
+++ b/storeganise/handler.js
@@ -10,7 +10,7 @@ const storeganiseBusinessCode = process.env.storeganise_business_code;
 const storeganiseApiKey = process.env.storeganise_api_key;
 
 // Finverse client id and secrets are sensitive fields and should be stored in the appropriate location for secrets
-// currently string as runtime variables as part of v1. Should move to secret manager as part of official production-ization
+// currently storing as runtime variables as part of v1. Should move to secret manager as part of official production-ization
 const finverseClientId = process.env.finverse_client_id;
 const finverseClientSecret = process.env.finverse_client_secret;
 

--- a/storeganise/handler.test.js
+++ b/storeganise/handler.test.js
@@ -1,0 +1,56 @@
+const { finverseWebhookHandler } = require('./handler');
+
+describe('finverseWebhookHandler', () => {
+  // pass this object to the handler to record the responses the function intends to return
+  let mockResponse;
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    mockResponse = {
+      send: jest.fn(),
+      status: jest.fn(),
+    };
+    mockResponse.status.mockReturnValue(mockResponse);
+  });
+
+  test('/payments path - should return OK', async () => {
+    await finverseWebhookHandler(
+      {
+        path: '/payments',
+      },
+      mockResponse
+    );
+
+    expect(mockResponse.send).toHaveBeenCalledTimes(1);
+    expect(mockResponse.send).toHaveBeenCalledWith('OK');
+  });
+
+  test('/payment_links path - should return OK', async () => {
+    await finverseWebhookHandler(
+      {
+        path: '/payment_links',
+      },
+      mockResponse
+    );
+
+    expect(mockResponse.send).toHaveBeenCalledTimes(1);
+    expect(mockResponse.send).toHaveBeenCalledWith('OK');
+  });
+
+  test('unknown path - should return 404', async () => {
+    await finverseWebhookHandler(
+      {
+        path: '/unhandled_path',
+      },
+      mockResponse
+    );
+
+    expect(mockResponse.status).toHaveBeenCalledTimes(1);
+    expect(mockResponse.status).toHaveBeenCalledWith(404);
+
+    expect(mockResponse.send).toHaveBeenCalledTimes(1);
+    expect(mockResponse.send).toHaveBeenCalledWith(
+      'Path not found: /unhandled_path'
+    );
+  });
+});


### PR DESCRIPTION
handle `/payments` and `/payment_links`. Return 404 for all other paths

initialise SDKs (currently used) and define necessary variables