### PR TITLE
Fix missing params in index function

### DIFF
--- a/storeganise/index.js
+++ b/storeganise/index.js
@@ -17,7 +17,7 @@ const finverseClientId = process.env.finverse_client_id;
 const finverseClientSecret = process.env.finverse_client_secret;
 
 // Should set the entry point in Google Cloud Functions to `storeganiseHelper` so that it uses this function
-functions.http('storeganiseHelper', async () => {
+functions.http('storeganiseHelper', async (req, res) => {
   const finverseSdk = new FinverseSdk(finverseClientId, finverseClientSecret);
   const storeganiseSdk = new StoreganiseSdk(
     storeganiseBusinessCode,

--- a/storeganise/package.json
+++ b/storeganise/package.json
@@ -12,7 +12,6 @@
   "devDependencies": {
     "jest": "^29.7.0"
   },
-  "type": "module",
   "scripts": {
     "test": "node ./node_modules/jest/bin/jest.js ./"
   }


### PR DESCRIPTION
Passing undefined `req` and `res` to handler. Will lead to runtime error