### PR TITLE
Update storeganise user write

### DIFF
--- a/storeganise/sdk/storeganise.js
+++ b/storeganise/sdk/storeganise.js
@@ -58,10 +58,6 @@ class StoreganiseSdk {
       await this.fetchSg(`users/${storeganiseUserId}`, {
         method: 'PUT',
         body: {
-          billing: {
-            id: finversePaymentMethodId,
-            type: 'custom',
-          },
           custom: {
             finverse_payment_method_id: finversePaymentMethodId,
           },

--- a/storeganise/sdk/storeganise.js
+++ b/storeganise/sdk/storeganise.js
@@ -58,7 +58,7 @@ class StoreganiseSdk {
       await this.fetchSg(`users/${storeganiseUserId}`, {
         method: 'PUT',
         body: {
-          custom: {
+          customFields: {
             finverse_payment_method_id: finversePaymentMethodId,
           },
         },

--- a/storeganise/sdk/storeganise.test.js
+++ b/storeganise/sdk/storeganise.test.js
@@ -15,10 +15,6 @@ describe('Storeganise SDK', () => {
     expect(sdk.fetchSg).toHaveBeenCalledWith('users/storeganiseUserId', {
       method: 'PUT',
       body: {
-        billing: {
-          id: 'finversePaymentMethodId',
-          type: 'custom',
-        },
         custom: {
           finverse_payment_method_id: 'finversePaymentMethodId',
         },

--- a/storeganise/sdk/storeganise.test.js
+++ b/storeganise/sdk/storeganise.test.js
@@ -15,7 +15,7 @@ describe('Storeganise SDK', () => {
     expect(sdk.fetchSg).toHaveBeenCalledWith('users/storeganiseUserId', {
       method: 'PUT',
       body: {
-        custom: {
+        customFields: {
           finverse_payment_method_id: 'finversePaymentMethodId',
         },
       },


### PR DESCRIPTION
Cannot pass `billing` anymore; storeganise returns 4XX error

Replace `custom` with `customFields` since that is the more appropriate field name